### PR TITLE
Implemented auto-rest mode

### DIFF
--- a/analmidi.js
+++ b/analmidi.js
@@ -35,7 +35,8 @@ function analmidi(midiobj) {
         "type": "on",
         "midi": note.midi,
         "channel": note.channel,
-        "velocity": note.velocity
+        "velocity": note.velocity,
+        "duration": midiobj.header.ticksToSeconds(note.durationTicks)
       }, parseInt(note.ticks));
       // add noteOff msg to events
       place(grinderobj, {

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
       const files = e.target.files
 				if (files.length > 0){
 					const file = files[0];
-          parseFile(file);
+                    parseFile(file);
 					document.querySelector("#FileDrop #Text").textContent = file.name
 					
 				}
@@ -76,7 +76,7 @@
       reader.onload = function(e){
         const midi = new Midi(e.target.result);
         currentMidi = midi;
-        grinder = new MightyMeatyMIDIGrindr(analmidi(currentMidi));
+        grinder = new MightyMeatyMIDIGrindr(currentMidi, analmidi(currentMidi));
         displayGrindInfo();
         document.getElementById('grinder').src = "img/grinder2.png";
       }


### PR DESCRIPTION
Envisioning five modes for the managing of note-offs

(1) Auto-play original-duration note-offs
(2) Force legato (rounding mid-duration note-offs forward)
(3) User must play all note-off events
(4) Key-up event triggers all mid-duration note-offs
(5) Auto-play only mid-duration note-offs

Mode (5) has been implemented in this change, hard-coded but preserving code for mode (3) from previous version. Other modes remain to be implemented.

Changed behavior: current code throws error when reaching penultimate grind place, instead of looping back to beginning as before.